### PR TITLE
Doc: Fix typos in Readme.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cd ForkTheCaptcha
 <br>
 
 ## 🧑‍💻 How to Contribute
-We'd love for you to contribute to ForkTheCaptcha and make it better! You can add new features, make desgin responsive, fix any issue or bug, change styling as long as code doesn't break!
+We'd love for you to contribute to ForkTheCaptcha and make it better! You can add new features, make design responsive, fix any issue or bug, change styling as long as code doesn't break!
 
 To contribute:
 


### PR DESCRIPTION
Hi, while reading the readme documentation, I came across the typo and fixed it.

- desgin → design