### PR TITLE
Fix: Mobile hamburger toggles navbar visibility on small screens

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/about.html
+++ b/about.html
@@ -93,5 +93,6 @@
     <footer>
       <p>&copy; 2024 ForkTheCaptcha. All rights reserved.</p>
     </footer>
+    <script src="js/navbar.js"></script>
   </body>
 </html>

--- a/contributors.html
+++ b/contributors.html
@@ -38,5 +38,6 @@
 
     
     <script src="./js/contributor.js"></script>
+    <script src="./js/navbar.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
 	<script src="js/speechrecog.js"></script>
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
 	<script src="js/codefont.js"></script>
+	<script src="js/navbar.js"></script>
 
 	
 </body>

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const menuIcon = document.querySelector('.menu-icon');
+  const navLinks = document.querySelector('.nav-links');
+
+  if (!menuIcon || !navLinks) return;
+
+  menuIcon.addEventListener('click', function () {
+    navLinks.classList.toggle('show');
+  });
+
+  // Close menu after clicking a link on small screens
+  navLinks.querySelectorAll('a').forEach(function (link) {
+    link.addEventListener('click', function () {
+      if (navLinks.classList.contains('show')) {
+        navLinks.classList.remove('show');
+      }
+    });
+  });
+});
+

--- a/styles/style.css
+++ b/styles/style.css
@@ -355,10 +355,17 @@ footer {
         padding: 10px;
     }
 
+    /* Hide links by default on mobile */
     .nav-links {
+        display: none;
         flex-direction: column; /* Stack links vertically */
         width: 100%;
         padding: 10px 0;
+    }
+
+    /* Show when toggled */
+    .nav-links.show {
+        display: flex;
     }
 
     .nav-links li {


### PR DESCRIPTION

### **Summary**
Implements a working hamburger toggle for the navbar on mobile.
Hides nav links by default at ≤768px; shows them when toggled.
Auto-closes the menu after selecting a link.

### Changes
Added js/navbar.js with toggle logic.
Updated styles/style.css to:
Hide .nav-links on mobile and show when .show is present.
Ensure .menu-icon is visible on mobile.
Included js/navbar.js in:
index.html
about.html
contributors.html

**### Before**
Hamburger icon visible but non-functional.
Menu links always visible on mobile, overlaying content.
### **After**
Tapping hamburger toggles the menu open/closed.
Links hidden by default on mobile and shown only when toggled.
Menu auto-closes after tapping a link.


### Technical Notes
Toggle implemented by adding/removing .show on .nav-links.
Uses DOMContentLoaded to safely attach listeners.
No breaking changes to desktop layout.

### Testing
Resize to mobile (≤768px) or use DevTools device emulation.
Verify:
Nav links hidden by default.
Tapping hamburger shows/hides menu.
Tapping any nav link closes the menu.
Desktop layout remains unchanged.

### Files Touched
js/navbar.js (new)
styles/style.css
index.html
about.html
contributors.html

### Screenshots
**Before**: 
<img width="436" height="729" alt="Screenshot 2025-10-29 at 3 02 51 PM" src="https://github.com/user-attachments/assets/930a5901-de84-4034-96a8-52f077285034" />
**After**: 
<img width="457" height="714" alt="Screenshot 2025-10-30 at 12 40 48 AM" src="https://github.com/user-attachments/assets/09c16e85-c5b3-45b3-a48a-82dd6b319aae" />


### Checklist
[x] Mobile nav hides by default
[x] Hamburger toggles menu
[x] Menu closes after link click
[x] No console errors
[x] Desktop unaffected

### Release Notes
Mobile navbar now collapses/expands via hamburger toggle; improves usability on small screens.

